### PR TITLE
Fixed typo mistake

### DIFF
--- a/virtualgrid/fundamentals/element-hierarchy.md
+++ b/virtualgrid/fundamentals/element-hierarchy.md
@@ -14,7 +14,7 @@ __RadVirtualGrid__ uses the [Telerik Presentation Framework]({%slug winforms/tel
 
 ![virtualgrid-fundamentals-element-hierarchy001](images/virtualgrid-fundamentals-element-hierarchy001.png)    
 
-* __VirtualGridElement:__ Tis is the root element in grid hierarchy. It contains all other grid elements.
+* __VirtualGridElement:__ This is the root element in grid hierarchy. It contains all other grid elements.
 
 * __VirtualGridTableElement:__ The element that contains all visual rows shown in the grid. If the hierarchical grid is used each child view has it own table element. The element can be accessed via the __TableElement__ property and exposes useful row/cell properties.
 
@@ -22,7 +22,7 @@ __RadVirtualGrid__ uses the [Telerik Presentation Framework]({%slug winforms/tel
 
 * __VirtualGridCellElement:__ This is the base visual element for presenting cells. It references __VirtaulGridRowElement__ objects.
 
-* __Scrollbar Elements:__ instead of using the build-in WinForms mechanism for scrolling, __RadVirtualGrid__ uses elements and implements custom logic. Scrollbar elements are accessible using the __HScrollBar__ and __VScrollBar__ properties of __TableElement__. When using hierarchy, you can choose between a single scrollbar and dedicated scrollbar elements in every child view. To do this, set the __UseScrollbarsInHierarchy__ property to *true*.
+* __Scrollbar Elements:__ Instead of using the build-in WinForms mechanism for scrolling, __RadVirtualGrid__ uses elements and implements custom logic. Scrollbar elements are accessible using the __HScrollBar__ and __VScrollBar__ properties of __TableElement__. When using hierarchy, you can choose between a single scrollbar and dedicated scrollbar elements in every child view. To do this, set the __UseScrollbarsInHierarchy__ property to *true*.
 
 
 


### PR DESCRIPTION
Fixed typo of 'Tis' to 'This' and changed "instead" to "Instead" as for each element definition it started with capital letters.