### PR TITLE
AI Search Gap: Highlighting Child Grid Headers on Expansion in Hierar…

### DIFF
--- a/controls/gridview/hierarchical-grid/how-to/applying-formatting-only-to-cells-in-a-child-template.md
+++ b/controls/gridview/hierarchical-grid/how-to/applying-formatting-only-to-cells-in-a-child-template.md
@@ -32,6 +32,43 @@ You can use the following code snippet to change the header height of the first 
 <snippet id='gridview-howto-example2-cs' />
 <snippet id='gridview-howto1-example2-vb' />
 
+### Example 3
+
+To change the background color of **header** cells belonging only to child templates, handle the `ViewCellFormatting` event:
+
+#### Highlighting Child Header Cells
+
+````C#
+private void radGridView1_ViewCellFormatting(object sender, CellFormattingEventArgs e)
+{
+    if (e.CellElement is GridHeaderCellElement && e.CellElement.ViewTemplate.Parent != null)
+    {
+        e.CellElement.DrawFill = true;
+        e.CellElement.GradientStyle = GradientStyles.Solid;
+        e.CellElement.BackColor = Color.LightYellow;
+    }
+    else if (e.CellElement is GridHeaderCellElement)
+    {
+        e.CellElement.ResetValue(LightVisualElement.BackColorProperty, ValueResetFlags.Local);
+        e.CellElement.ResetValue(LightVisualElement.GradientStyleProperty, ValueResetFlags.Local);
+        e.CellElement.ResetValue(LightVisualElement.DrawFillProperty, ValueResetFlags.Local);
+    }
+}
+````
+````VB.NET
+Private Sub RadGridView1_ViewCellFormatting(ByVal sender As Object, ByVal e As CellFormattingEventArgs)
+    If TypeOf e.CellElement Is GridHeaderCellElement AndAlso e.CellElement.ViewTemplate.Parent IsNot Nothing Then
+        e.CellElement.DrawFill = True
+        e.CellElement.GradientStyle = GradientStyles.Solid
+        e.CellElement.BackColor = Color.LightYellow
+    ElseIf TypeOf e.CellElement Is GridHeaderCellElement Then
+        e.CellElement.ResetValue(LightVisualElement.BackColorProperty, ValueResetFlags.Local)
+        e.CellElement.ResetValue(LightVisualElement.GradientStyleProperty, ValueResetFlags.Local)
+        e.CellElement.ResetValue(LightVisualElement.DrawFillProperty, ValueResetFlags.Local)
+    End If
+End Sub
+````
+
 # See Also
 * [Accessing Child Templates]({%slug winforms/gridview/hierarchical-grid/how-to/accessing-child-templates%})
 

--- a/controls/gridview/hierarchical-grid/how-to/applying-formatting-only-to-cells-in-a-child-template.md
+++ b/controls/gridview/hierarchical-grid/how-to/applying-formatting-only-to-cells-in-a-child-template.md
@@ -34,7 +34,7 @@ You can use the following code snippet to change the header height of the first 
 
 ### Example 3
 
-To change the background color of **header** cells belonging only to child templates, handle the `ViewCellFormatting` event:
+To change the background color of **header** cells belonging only to child templates, subscribe to (or handle via the designer) the `ViewCellFormatting` event:
 
 #### Highlighting Child Header Cells
 


### PR DESCRIPTION
…chical RadGridView

Decision
Recommend — Add a section and code snippet to controls/gridview/hierarchical-grid/how-to/applying-formatting-only-to-cells-in-a-child-template.md demonstrating how to format child header rows using ViewRowFormatting / ViewCellFormatting. Confidence: High
Gap: Incomplete content / Missing example

Why
Customer need: Code sample and explanation for highlighting the header of child views when child rows are expanded in a hierarchical RadGridView. Current gap: Existing documentation in applying-formatting-only-to-cells-in-a-child-template.md only shows changing data cells' BackColor via CellFormatting and setting child header height, but does not show how to highlight/color child header cells or rows using ViewCellFormatting / ViewRowFormatting. Preferred approach: Add an Example to controls/gridview/hierarchical-grid/how-to/applying-formatting-only-to-cells-in-a-child-template.md illustrating child header styling with ViewCellFormatting. Not selected: Creating a standalone new article. The existing article applying-formatting-only-to-cells-in-a-child-template.md already owns formatting child templates in hierarchy; adding this directly strengthens the canonical article without creating fragmenting duplicates.